### PR TITLE
Fix repourl

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -12,7 +12,7 @@ ifdef::env-github[]
 :note-caption: :information_source:
 :warning-caption: :warning:
 endif::[]
-:repoURL: https://github.com/CS2103-AY1819S1-T09-2/main
+:repoURL: https://github.com/CS2103-AY1819S1-T09-2/main/tree/master
 
 By: `Team T09-2`      Since: `Aug 2018`      Licence: `MIT`
 


### PR DESCRIPTION
Right now our links doesn't work because the `repoURL` variable is incorrectly configured