### PR TITLE
Resolve issue #162, add list command, update exceptions thrown with cards operation

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCardCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCardCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_NOT_INSIDE_DECK;
 
 import java.util.List;
 
@@ -10,6 +11,7 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.deck.Card;
+import seedu.address.model.deck.anakinexceptions.DeckNotFoundException;
 
 
 /**
@@ -46,8 +48,13 @@ public class DeleteCardCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_CARD_DISPLAYED_INDEX);
         }
         Card cardToDelete = lastShownList.get(targetIndex.getZeroBased());
-        model.deleteCard(cardToDelete);
-        model.commitAnakin();
+        try {
+            model.deleteCard(cardToDelete);
+            model.commitAnakin();
+        } catch (DeckNotFoundException e) {
+            throw new CommandException(MESSAGE_NOT_INSIDE_DECK);
+        }
+
         return new CommandResult(String.format(MESSAGE_DELETE_CARD_SUCCESS, cardToDelete));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCardCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCardCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_NOT_INSIDE_DECK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ANSWER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_QUESTION;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CARDS;
@@ -17,6 +18,7 @@ import seedu.address.model.Model;
 import seedu.address.model.deck.Answer;
 import seedu.address.model.deck.Card;
 import seedu.address.model.deck.Question;
+import seedu.address.model.deck.anakinexceptions.DeckNotFoundException;
 
 /**
  * Edits the details of an existing card in a deck.
@@ -82,10 +84,15 @@ public class EditCardCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_CARD);
         }
 
-        model.updateCard(cardToEdit, editedCard);
-        model.updateFilteredCardList(PREDICATE_SHOW_ALL_CARDS);
+        try {
+            model.updateCard(cardToEdit, editedCard);
+            model.updateFilteredCardList(PREDICATE_SHOW_ALL_CARDS);
+            model.commitAnakin();
+        } catch (DeckNotFoundException e) {
+            throw new CommandException(MESSAGE_NOT_INSIDE_DECK);
+        }
+
         // TODO: Check that card changes are saved when committing
-        model.commitAnakin();
         return new CommandResult(String.format(MESSAGE_EDIT_CARD_SUCCESS, editedCard));
     }
 

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,25 +1,33 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CARDS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_DECKS;
 
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 
 
 /**
- * Lists all persons in the address book to the user.
+ * Lists all decks / cards in the current list to the user.
  */
 public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all decks";
+    public static final String MESSAGE_SUCCESS_DECK = "Listed all decks";
+    public static final String MESSAGE_SUCCESS_CARD = "Listed all cards";
 
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
-        model.updateFilteredDeckList(unusedVariable -> true);
-        return new CommandResult(MESSAGE_SUCCESS);
+        if (model.isInsideDeck()) {
+            model.updateFilteredCardList(PREDICATE_SHOW_ALL_CARDS);
+            return new CommandResult(MESSAGE_SUCCESS_CARD);
+        } else {
+            model.updateFilteredDeckList(PREDICATE_SHOW_ALL_DECKS);
+            return new CommandResult(MESSAGE_SUCCESS_DECK);
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/NewCardCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NewCardCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_NOT_INSIDE_DECK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ANSWER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_QUESTION;
 
@@ -8,6 +9,8 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.deck.Card;
+import seedu.address.model.deck.anakinexceptions.CardNotFoundException;
+import seedu.address.model.deck.anakinexceptions.DeckNotFoundException;
 
 
 /**
@@ -43,11 +46,15 @@ public class NewCardCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
-        if (model.hasCard(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_CARD);
+        try {
+            if (model.hasCard(toAdd)) {
+                throw new CommandException(MESSAGE_DUPLICATE_CARD);
+            }
+            model.addCard(toAdd);
+            model.commitAnakin();
+        } catch (DeckNotFoundException e) {
+            throw new CommandException(MESSAGE_NOT_INSIDE_DECK);
         }
-        model.addCard(toAdd);
-        model.commitAnakin();
         return new CommandResult(String.format(MESSAGE_NEW_CARD_SUCCESS, toAdd));
     }
 

--- a/src/main/java/seedu/address/logic/commands/NewCardCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NewCardCommand.java
@@ -9,7 +9,6 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.deck.Card;
-import seedu.address.model.deck.anakinexceptions.CardNotFoundException;
 import seedu.address.model.deck.anakinexceptions.DeckNotFoundException;
 
 

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ImportDeckCommand;
+import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.NewCardCommand;
 import seedu.address.logic.commands.NewDeckCommand;
 import seedu.address.logic.commands.RedoCommand;
@@ -98,6 +99,9 @@ public class Parser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ListCommand.COMMAND_WORD:
+            return new ListCommand();
 
         case ExportDeckCommand.COMMAND_WORD:
             return new ExportDeckCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/model/Anakin.java
+++ b/src/main/java/seedu/address/model/Anakin.java
@@ -172,6 +172,10 @@ public class Anakin implements ReadOnlyAnakin {
      */
     public void removeDeck(Deck deck) {
         decks.remove(deck);
+        if (deck.getCards().equals(cards)) {
+            cards = new UniqueCardList();
+            updateDisplayedCards();
+        }
     }
 
     //// card-level operations

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -13,7 +13,6 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.model.AnakinChangedEvent;
 import seedu.address.model.deck.Card;
 import seedu.address.model.deck.Deck;
-import seedu.address.model.deck.anakinexceptions.CardNotFoundException;
 import seedu.address.model.deck.anakinexceptions.DeckNotFoundException;
 import seedu.address.storage.portmanager.PortManager;
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -13,6 +13,8 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.model.AnakinChangedEvent;
 import seedu.address.model.deck.Card;
 import seedu.address.model.deck.Deck;
+import seedu.address.model.deck.anakinexceptions.CardNotFoundException;
+import seedu.address.model.deck.anakinexceptions.DeckNotFoundException;
 import seedu.address.storage.portmanager.PortManager;
 
 /**
@@ -102,26 +104,26 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     @Override
-    public boolean hasCard(Card card) {
+    public boolean hasCard(Card card) throws DeckNotFoundException {
         requireAllNonNull(card);
         return versionedAnakin.hasCard(card);
     }
 
     @Override
-    public void deleteCard(Card card) {
+    public void deleteCard(Card card) throws DeckNotFoundException {
         versionedAnakin.removeCard(card);
         indicateAnakinChanged();
     }
 
     @Override
-    public void addCard(Card card) {
+    public void addCard(Card card) throws DeckNotFoundException {
         versionedAnakin.addCard(card);
         updateFilteredCardList(PREDICATE_SHOW_ALL_CARDS);
         indicateAnakinChanged();
     }
 
     @Override
-    public void updateCard(Card target, Card editedCard) {
+    public void updateCard(Card target, Card editedCard) throws DeckNotFoundException {
         requireAllNonNull(target, editedCard);
 
         versionedAnakin.updateCard(target, editedCard);

--- a/src/main/java/seedu/address/storage/portmanager/PortManager.java
+++ b/src/main/java/seedu/address/storage/portmanager/PortManager.java
@@ -120,7 +120,7 @@ public class PortManager implements Porter {
      */
 
     private Path makeFilePath(String name) {
-        if (name.substring(name.length() - 4).equals(".xml")) {
+        if (name.length() > 4 && name.substring(name.length() - 4).equals(".xml")) {
             return baseFilePath.resolve(name);
         } else {
             return baseFilePath.resolve(name + ".xml");

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -41,7 +41,7 @@
 //    @Test
 //    public void execute_validCommand_success() {
 //        String listCommand = ListCommand.COMMAND_WORD;
-//        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, addressbookModel);
+//        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS_DECK, addressbookModel);
 //        assertHistoryCorrect(listCommand);
 //    }
 //
@@ -121,7 +121,7 @@
 //        try {
 //            CommandResult result = addressbookLogic.execute(HistoryCommand.COMMAND_WORD);
 //            String expectedMessage = String.format(
-//                HistoryCommand.MESSAGE_SUCCESS, String.join("\n", expectedCommands));
+//                HistoryCommand.MESSAGE_SUCCESS_DECK, String.join("\n", expectedCommands));
 //            assertEquals(expectedMessage, result.feedbackToUser);
 //        } catch (ParseException | CommandException e) {
 //            throw new AssertionError("Parsing and execution of HistoryCommand.COMMAND_WORD should succeed.", e);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Anakin;
 import seedu.address.model.Model;
 import seedu.address.model.deck.Card;
+import seedu.address.model.deck.CardQuestionContainsKeywordsPredicate;
 import seedu.address.model.deck.Deck;
 import seedu.address.model.deck.DeckNameContainsKeywordsPredicate;
 import seedu.address.testutil.EditDeckDescriptorBuilder;
@@ -134,6 +135,23 @@ public class CommandTestUtil {
             new DeckNameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredDeckList().size());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show only the CARD at the given {@code targetIndex} in the
+     * {@code model}'s current deck.
+     */
+
+    public static void showCardAtIndexOfCurrentDeck(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredCardList().size());
+
+        Card card = model.getFilteredCardList().get(targetIndex.getZeroBased());
+
+        final String[] splitName = card.getQuestion().fullQuestion.split("\\s+");
+        model.updateFilteredCardList(
+                new CardQuestionContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+
+        assertEquals(1, model.getFilteredCardList().size());
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showCardAtIndexOfCurrentDeck;
+import static seedu.address.logic.commands.CommandTestUtil.showDeckAtIndex;
+import static seedu.address.testutil.TypicalDecks.DECK_WITH_CARDS;
+import static seedu.address.testutil.TypicalDecks.getTypicalAnakin;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CARD;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_DECK;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
+ */
+public class ListCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Before
+    public void setUp() {
+        model = new ModelManager(getTypicalAnakin(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAnakin(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_listIsNotFiltered_showsSameList() {
+        assertCommandSuccess(new ListCommand(), model, commandHistory,
+                ListCommand.MESSAGE_SUCCESS_DECK, expectedModel);
+
+        model.getIntoDeck(DECK_WITH_CARDS);
+        expectedModel.getIntoDeck(DECK_WITH_CARDS);
+        assertCommandSuccess(new ListCommand(), model, commandHistory,
+                ListCommand.MESSAGE_SUCCESS_CARD, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsFiltered_showsEverything() {
+        showDeckAtIndex(model, INDEX_FIRST_DECK);
+        assertCommandSuccess(new ListCommand(), model, commandHistory,
+                ListCommand.MESSAGE_SUCCESS_DECK, expectedModel);
+
+        model.getIntoDeck(DECK_WITH_CARDS);
+        expectedModel.getIntoDeck(DECK_WITH_CARDS);
+        showCardAtIndexOfCurrentDeck(model, INDEX_FIRST_CARD);
+        assertCommandSuccess(new ListCommand(), model, commandHistory,
+                ListCommand.MESSAGE_SUCCESS_CARD, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/NewCardCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/NewCardCommandTest.java
@@ -24,7 +24,6 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyAnakin;
 import seedu.address.model.deck.Card;
 import seedu.address.model.deck.Deck;
-import seedu.address.model.deck.anakinexceptions.DeckNotFoundException;
 import seedu.address.testutil.CardBuilder;
 import seedu.address.testutil.DeckBuilder;
 

--- a/src/test/java/seedu/address/logic/commands/NewCardCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/NewCardCommandTest.java
@@ -24,6 +24,7 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyAnakin;
 import seedu.address.model.deck.Card;
 import seedu.address.model.deck.Deck;
+import seedu.address.model.deck.anakinexceptions.DeckNotFoundException;
 import seedu.address.testutil.CardBuilder;
 import seedu.address.testutil.DeckBuilder;
 
@@ -73,7 +74,7 @@ public class NewCardCommandTest {
         Card validCard = CARD_B;
         NewCardCommand newCardCommand = new NewCardCommand(validCard);
         Model model = testModel;
-        thrown.expect(RuntimeException.class);
+        thrown.expect(CommandException.class);
         newCardCommand.execute(model, commandHistory);
 
     }


### PR DESCRIPTION
Card-level operations should throw DeckNotFoundException when they are execute outside a deck
Issue #162 is fixed with a temporary solution